### PR TITLE
Quick fix on config.py

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,2 +1,2 @@
-delete_for_real = None
+delete_for_real = False
 days_to_observe = 30


### PR DESCRIPTION
this is a quick fix so the wizards work when they are excecuted individually outside of main, when delete_for_real was set to None they wouldn't log or attempt deletion properly so now it's set to False for default.